### PR TITLE
:lock: feat: google adc

### DIFF
--- a/pipelines/test.py
+++ b/pipelines/test.py
@@ -28,4 +28,4 @@ async def test(version: str):
 
 
 if __name__ == '__main__':
-    anyio.run(test)
+    anyio.run(test, "3.11.3")

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ requests==2.31.0
 cdktf-cdktf-provider-google==7.0.7
 Jinja2==3.1.2
 python-terraform==0.10.1
+google-auth==2.19.0

--- a/thipster/auth/Google.py
+++ b/thipster/auth/Google.py
@@ -1,5 +1,4 @@
-import json
-import os
+import google.auth
 from thipster.engine.I_Auth import I_Auth
 from cdktf_cdktf_provider_google.provider import GoogleProvider
 
@@ -9,7 +8,7 @@ class GoogleAuth(I_Auth):
 
     Methods
     -------
-    authenticate(self: Construct)
+    authenticate(app: Construct)
         Generates the google provider in terraform
 
     """
@@ -17,28 +16,20 @@ class GoogleAuth(I_Auth):
     def __init__(self) -> None:
         return GoogleAuth
 
-    def authenticate(self):
-        credentials = os.getenv("GOOGLE_CREDENTIALS")
+    def authenticate(app):
+        """Generates the google provider block for the Terraform CDK
 
-        if not credentials:
-            print("-"*10, "Authentication", "-"*10)
-            print("No authentication found in GOOGLE_CREDENTIALS")
-            credentials = input("Relative path to credentials file : ")
+        Parameters
+        ----------
+        app: Construct
+            CDK Construct where the provider is created
 
-        if not os.path.isfile(credentials):
-            project = json.loads(credentials)["project_id"]
-        else:
-            with open(credentials) as f:
-                project = json.loads(f.read())["project_id"]
-                f.close()
+        """
+
+        credentials, project_id = google.auth.default()
 
         GoogleProvider(
-            self, "default_google",
-            project=project,
-            credentials=credentials if not os.path.isfile(credentials)
-            or os.path.isabs(credentials)
-            else os.path.join(
-                os.getcwd(),
-                credentials,
-            ),
+            app, "default_google",
+            project=project_id,
+            access_token=credentials.token,
         )


### PR DESCRIPTION
New workflow : 

- Login to gcloud using 
`gcloud auth application-default login`
or 
`gcloud auth application-default login --impersonate-service-account SERVICE_ACCOUNT_EMAIL`
(you need iam.serviceAccounts.getAccessToken permission in gcloud to work)

- Use THipster freely, Google will fins login data automatically
