### PR TITLE
:green_heart: fix: skip ci on release commit (#129)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ patch_emoji = ":ambulance:,:bug:,:adhesive_bandage:,:lock:,:arrow_up:,:arrow_dow
 
 repository_url = "https://upload.pypi.org/legacy/"
 
-commit_subject = ":bookmark: {version}"
+commit_subject = ":bookmark: {version} [skip ci]"
 major_on_zero = false
 
 [pytest]


### PR DESCRIPTION
closes #129 