### PR TITLE
:bug: fix: no crash on non-parsable files

### DIFF
--- a/tests/parser/test_parserfactory.py
+++ b/tests/parser/test_parserfactory.py
@@ -1,5 +1,8 @@
+import pytest
+
 from thipster.engine.parsed_file import ParsedFile
 from thipster.parser import ParserFactory
+from thipster.parser.exceptions import NoFileFoundError
 
 from ..test_tools import create_dir
 
@@ -113,3 +116,39 @@ def test_two_types_of_file():
         region = bucket.attributes[0]
         assert region.name == 'region'
         assert region.value == 'euw'
+
+
+def test_no_parsable_file():
+    with pytest.raises(NoFileFoundError):
+        __test_file(
+            {
+                'test_file.txt':
+                """ """,
+                'test_file2.txt':
+                """ """,
+            },
+        )
+
+
+def test_one_parsable_file():
+    out = __test_file(
+        {
+            'test_file.thips':
+            """bucket my-bucket1:
+\tregion: euw
+""",
+            'test_file2.txt':
+            """ """,
+        },
+    )
+
+    assert len(out.resources) == 1
+
+    bucket = out.resources[0]
+    assert bucket.resource_type == 'bucket'
+    assert bucket.name == 'my-bucket1'
+    assert len(bucket.attributes) == 1
+
+    region = bucket.attributes[0]
+    assert region.name == 'region'
+    assert region.value == 'euw'

--- a/thipster/parser/exceptions.py
+++ b/thipster/parser/exceptions.py
@@ -1,0 +1,23 @@
+from thipster.engine import THipsterError
+
+
+class ParserPathNotFoundError(THipsterError):
+    def __init__(self, path, *args: object) -> None:
+        super().__init__(*args)
+
+        self.__path = path
+
+    @property
+    def message(self) -> str:
+        return f'Path not found : {self.__path}'
+
+
+class NoFileFoundError(THipsterError):
+    def __init__(self, path, *args: object) -> None:
+        super().__init__(*args)
+
+        self.__path = path
+
+    @property
+    def message(self) -> str:
+        return f'No files to parse in {self.__path}'

--- a/thipster/parser/yaml_parser.py
+++ b/thipster/parser/yaml_parser.py
@@ -1,4 +1,5 @@
 import os
+from abc import ABC
 
 import yaml
 from jinja2 import Environment, FileSystemLoader
@@ -6,20 +7,12 @@ from jinja2 import Environment, FileSystemLoader
 import thipster.engine.parsed_file as pf
 from thipster.engine import ParserPort, THipsterError
 
+from .exceptions import ParserPathNotFoundError
 
-class YAMLParserBaseError(THipsterError):
+
+class YAMLParserBaseError(THipsterError, ABC):
     def __init__(self, *args: object) -> None:
         super().__init__(*args)
-
-
-class YAMLParserPathNotFoundError(YAMLParserBaseError):
-    def __init__(self, file, *args: object) -> None:
-        super().__init__(*args)
-        self.file = file
-
-    @property
-    def message(self) -> str:
-        return f'Path not found : {self.file}'
 
 
 class YAMLParserNoNameError(YAMLParserBaseError):
@@ -52,7 +45,7 @@ class YAMLParser(ParserPort):
         path = os.path.abspath(path)
 
         if not os.path.exists(path):
-            raise YAMLParserPathNotFoundError(path)
+            raise ParserPathNotFoundError(path)
 
         files = []
 


### PR DESCRIPTION
# Description

Made the parser-factory more tolerant when ran on a directory : 
- no more error when ran against a non-recognized file
- new error (NoFileFoundError) when no parsable file found in directory

Fixes #156 

## Type of change

:bug: Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?
test against a directory with parsable and non-parsable files
test against a directory only non-parsable files

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
